### PR TITLE
fix(migration): bad import in first migration

### DIFF
--- a/migrations/versions/8d0d09f3990a_.py
+++ b/migrations/versions/8d0d09f3990a_.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-import togger
+import togger.database
 
 revision = '8d0d09f3990a'
 down_revision = None


### PR DESCRIPTION
There was a bad import in the very first migration that prevented me from deploying the app on heroku.