### PR TITLE
fix(colors): wrong displayed color on dayGridMonth and listWeek

### DIFF
--- a/togger/templates/fullcalendar.js
+++ b/togger/templates/fullcalendar.js
@@ -156,7 +156,20 @@ document.addEventListener('DOMContentLoaded', function() {
         nowIndicator: true,
         dayMaxEvents: true, // allow "more" link when too many events
         events: "{{ url_for('event_api.get_events') }}",
-        eventColor: '#9F9C99'
+        eventColor: '#9F9C99',
+        eventDidMount: function(info) {
+          // Change color of dot marker
+          var dotEl = info.el.getElementsByClassName('fc-daygrid-event-dot')[0];
+          if (dotEl) {
+            dotEl.style.borderColor = info.event.backgroundColor
+          }
+
+          // Change color of dot marker
+          var dotEl2 = info.el.getElementsByClassName('fc-list-event-dot')[0];
+          if (dotEl2) {
+            dotEl2.style.borderColor = info.event.backgroundColor
+          }
+      }
     });
     calendar.render();
     // https://stackoverflow.com/questions/61987141/dyanmic-change-text-on-custombuttons


### PR DESCRIPTION
It seems the border-color of the dot on these views remain blue. The direct
consequence is that it hides the updated (e.g. green or orange) background
color for the dot.

**Before Fix:**
![image](https://user-images.githubusercontent.com/19969519/102015938-aaff2480-3d5e-11eb-87cd-32a1b304bfa4.png)

The dot is supposed to be Orange or Green
**After fix:** 

![image](https://user-images.githubusercontent.com/19969519/102015915-8c992900-3d5e-11eb-8622-6eece2ca3f13.png)

In my opinion, that it would be best if the default color for an event was red instead of grey.
Also note that i'm not a frontend dev, so it might not be the best way to do this.