### PR TITLE
fix(events): cannot delete event with recur and shifts

### DIFF
--- a/togger/event/event_dao.py
+++ b/togger/event/event_dao.py
@@ -118,9 +118,8 @@ def remove_event(event_id):
     event = Event.query.filter(Event.id == event_id).filter(Event.calendar_id == calendar_id).first()
     if event.recur_id:
         event.hide = True
-        event.title = None
-        event.description = None
-        event.shifts = []
+        for shift in shifts:
+            db.session.delete(shift)
         db.session.merge(event)
     else:
         db.session.delete(event)


### PR DESCRIPTION
## Description

It fixes an issue where I cannot delete an event if it is based of a `RecurEvent` and it has at least one `Shift`

## How to reproduce

1. Create a RecurEvent
2. Volunteer for one shift on this RecurEvent
3. Try to delete the event where you volunteered

## Root Cause

When deleting you cannot : 
- change the Title to `None` as Event.title is not nullable
- change `shifts` to `[]` as it merges it by removing the `event_id` in the `Shift` table and `event_id` is not nullable